### PR TITLE
Fixed image name for dockerd-exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ configs:
 
 services:
   dockerd-exporter:
-    image: stefanprodan/caddy
+    image: stefanprodan/dockerd-exporter
     networks:
       - net
     environment:

--- a/weave-compose.yml
+++ b/weave-compose.yml
@@ -17,7 +17,7 @@ configs:
 
 services:
   dockerd-exporter:
-    image: stefanprodan/caddy
+    image: stefanprodan/dockerd-exporter
     networks:
       - net
     environment:


### PR DESCRIPTION
This might fix some of the issues people were having with `dockerd-exporter`