### PR TITLE
Update Traefik HTTP basic auth to current (not-deprecated) configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Services:
 
 ## Alternative install with Traefik and HTTPS
 
-If you have a Docker Swarm cluster with a global Traefik [set up as described in this article](https://medium.com/@tiangolo/docker-swarm-mode-and-traefik-for-a-https-cluster-20328dba6232), you can deploy Swarmprom integrated with that global Traefik proxy.
+If you have a Docker Swarm cluster with a global Traefik set up as described in [DockerSwarm.rocks](https://dockerswarm.rocks), you can deploy Swarmprom integrated with that global Traefik proxy.
 
 This way, each Swarmprom service will have its own domain, and each of them will be served using HTTPS, with certificates generated (and renewed) automatically.
 

--- a/README.md
+++ b/README.md
@@ -83,22 +83,16 @@ export ADMIN_PASSWORD=changethis
 export HASHED_PASSWORD=$(openssl passwd -apr1 $ADMIN_PASSWORD)
 ```
 
-* Set and export a single variable with the username and password in "`htpasswd`" format:
-
-```bash
-export USERNAME_PASSWORD=$ADMIN_USER:$HASHED_PASSWORD
-```
-
 * You can check the contents with:
 
 ```bash
-echo $USERNAME_PASSWORD
+echo $HASHED_PASSWORD
 ```
 
 it will look like:
 
 ```
-admin:$apr1$89eqM5Ro$CxaFELthUKV21DpI3UTQO.
+$apr1$89eqM5Ro$CxaFELthUKV21DpI3UTQO.
 ```
 
 * Create and export an environment variable `DOMAIN`, e.g.:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -136,7 +136,7 @@ services:
         - traefik.redirectorservice.frontend.redirect.entryPoint=https
         # Traefik service that listens to HTTPS
         - traefik.webservice.frontend.entryPoints=https
-        - traefik.frontend.auth.basic=${USERNAME_PASSWORD}
+        - traefik.frontend.auth.basic.users=${ADMIN_PASSWORD}:${HASHED_PASSWORD}
     networks:
       - default
       - net
@@ -162,7 +162,7 @@ services:
         - traefik.redirectorservice.frontend.redirect.entryPoint=https
         # Traefik service that listens to HTTPS
         - traefik.webservice.frontend.entryPoints=https
-        - traefik.frontend.auth.basic=${USERNAME_PASSWORD}
+        - traefik.frontend.auth.basic.users=${ADMIN_PASSWORD}:${HASHED_PASSWORD}
     networks:
       - default
       - net
@@ -230,7 +230,7 @@ services:
         - traefik.redirectorservice.frontend.redirect.entryPoint=https
         # Traefik service that listens to HTTPS
         - traefik.webservice.frontend.entryPoints=https
-        - traefik.frontend.auth.basic=${USERNAME_PASSWORD}
+        - traefik.frontend.auth.basic.users=${ADMIN_PASSWORD}:${HASHED_PASSWORD}
     networks:
       - default
       - net


### PR DESCRIPTION
Update Traefik HTTP basic auth to current (not-deprecated) configurations.

---

Also, I just created https://dockerswarm.rocks. With the same information as the medium post linked in the docs here.

And I added docs there to deploy Swarmprom too: https://dockerswarm.rocks/swarmprom/ :smile: 

Would you like me to update the link from the Medium post to https://dockerswarm.rocks or do you prefer to keep it pointing to Medium?