### PR TITLE
Fix incorrect env vars for Traefik deployment

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -136,7 +136,7 @@ services:
         - traefik.redirectorservice.frontend.redirect.entryPoint=https
         # Traefik service that listens to HTTPS
         - traefik.webservice.frontend.entryPoints=https
-        - traefik.frontend.auth.basic.users=${ADMIN_PASSWORD}:${HASHED_PASSWORD}
+        - traefik.frontend.auth.basic.users=${ADMIN_USER}:${HASHED_PASSWORD}
     networks:
       - default
       - net
@@ -162,7 +162,7 @@ services:
         - traefik.redirectorservice.frontend.redirect.entryPoint=https
         # Traefik service that listens to HTTPS
         - traefik.webservice.frontend.entryPoints=https
-        - traefik.frontend.auth.basic.users=${ADMIN_PASSWORD}:${HASHED_PASSWORD}
+        - traefik.frontend.auth.basic.users=${ADMIN_USER}:${HASHED_PASSWORD}
     networks:
       - default
       - net
@@ -230,7 +230,7 @@ services:
         - traefik.redirectorservice.frontend.redirect.entryPoint=https
         # Traefik service that listens to HTTPS
         - traefik.webservice.frontend.entryPoints=https
-        - traefik.frontend.auth.basic.users=${ADMIN_PASSWORD}:${HASHED_PASSWORD}
+        - traefik.frontend.auth.basic.users=${ADMIN_USER}:${HASHED_PASSWORD}
     networks:
       - default
       - net


### PR DESCRIPTION
I'm very sorry, in the last PR https://github.com/stefanprodan/swarmprom/pull/90 I used the wrong environment variables for the `ADMIN_USER`, I just realized that while updating DockerSwarm.rocks.

This PR corrects it.