### PR TITLE
Enable instant table for Docker nodes - Services

### DIFF
--- a/grafana/dashboards/swarmprom-services-dash.json
+++ b/grafana/dashboards/swarmprom-services-dash.json
@@ -1728,6 +1728,7 @@
         {
           "expr": "sum(engine_daemon_engine_info * on(instance) group_left(node_id) swarm_node_info) by (kernel, os, graphdriver, version, node_id)",
           "format": "table",
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",

--- a/grafana/dashboards/swarmprom-services-dash.json
+++ b/grafana/dashboards/swarmprom-services-dash.json
@@ -1707,7 +1707,7 @@
           "alias": "Time",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "pattern": "Time",
-          "type": "date"
+          "type": "hidden"
         },
         {
           "alias": "",


### PR DESCRIPTION
Enable instant table for Docker nodes to avoid duplicates