### PR TITLE
Remove deletion of existing Prometheus datasource

### DIFF
--- a/grafana/datasources/prometheus.yaml
+++ b/grafana/datasources/prometheus.yaml
@@ -1,8 +1,5 @@
 apiVersion: 1
 
-deleteDatasources:
-  - name: Prometheus
-
 datasources:
 - name: Prometheus
   type: prometheus


### PR DESCRIPTION
After setting up alerts within Grafana, I found that if the Prometheus instance was temporarily unavailable, this would cause the alert to fail permanently with: 

```
description = Error: Could not find datasource Data source not found
```

This would re-trigger until I went into Grafana, and manually re-tested the rule and saved the alert (with no actual changes to the alert, or data sources).

[This issue](https://github.com/grafana/grafana/issues/13004) suggests the cause is specifying `deleteDatasources` which has the same name as datasource defined after it.

I'm not aware of why this entry exists, so I have created this quick PR to remove it. If it's needed, please let me know and I'll look at other workarounds.