### PR TITLE
Add .yml extension to the location of prometheus rules files in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,8 +452,8 @@ ALERT node_disk_fill_rate_6h
 ```
 
 You can add alerts to
-[swarm_node](https://github.com/stefanprodan/swarmprom/blob/master/prometheus/rules/swarm_node.rules)
-and [swarm_task](https://github.com/stefanprodan/swarmprom/blob/master/prometheus/rules/swarm_task.rules)
+[swarm_node](https://github.com/stefanprodan/swarmprom/blob/master/prometheus/rules/swarm_node.rules.yml)
+and [swarm_task](https://github.com/stefanprodan/swarmprom/blob/master/prometheus/rules/swarm_task.rules.yml)
 files and rerun stack deploy to update them. Because these files are mounted inside the Prometheus
 container at run time as [Docker configs](https://docs.docker.com/engine/swarm/configs/)
 you don't have to bundle them with the image.


### PR DESCRIPTION
The original README.md has the location to two Promethues rules file which did not have the `.yml` extension. In the commit `6797cde141e6a94ded5bf395232517e4a8b717c4` where the extension was added, the README.md was not updated. These are just two lines of edit, adding the extension to the file names.